### PR TITLE
fix(setup.py): Add package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,14 @@ setup(
     url='https://github.com/CuriousLearner/django-phone-verify',
     author='Sanyam Khurana',
     author_email='sanyam@sanyamkhurana.com',
+    install_requires=[
+        'django>=2.1.5',
+        'djangorestframework>=3.9.0',
+        'python-dotenv>=0.10.0',
+        'phonenumbers>=8.10.2',
+        'django-phonenumber-field>=2.1.0',
+        'twilio>=6.21.0',
+    ],
     classifiers=[
         'Environment :: Web Environment',
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
In reference with #1, the package dependencies were not getting installed due to the absence of `install_requires` in the `setup()`.