### PR TITLE
i18n support

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,15 +56,18 @@ This would create ``SMSVerification`` table, which is used to store ``phone_numb
 i18n Support
 ------------
 
-If you would like to internationalize the verification messages, set `I18N` to `True`. This would cause the
-`PhoneVerificationService` to attempt to translate the `MESSAGE` string using Django's internationalization
-primitive `django.utils.translation.gettext`.
+If you would like to internationalize the verification messages, set the option ``I18N`` to ``True``. This would cause
+``PhoneVerificationService`` to attempt to translate the ``MESSAGE`` string using Django's internationalization
+primitive ``django.utils.translation.gettext``. Then define ``MESSAGE`` for all the desired locales that you want
+to support as per Django internationalization guidelines.
 
-To expose this capability to the clients, `PhoneVerificationService` constructor supports an additional parameter,
-`language`, which is the desired language locale code which will be looked up for a localized version of `MESSAGE`.
-Also, `VerificationViewSet.register` endpoint supports an optional `language` POST data argument where you can
+Under the hood, ``PhoneVerificationService`` constructor has been extended to support an additional parameter,
+``language``, which is the desired locale code which will be looked up for a localized version of ``MESSAGE``.
+Also, ``VerificationViewSet.register`` endpoint supports an optional ``language`` POST data argument where you can
 specify the locale code for the desired verification message language. This locale code will be eventually passed
-to `PhoneVerificationService`, to try and retrieve the localized message.
+to ``PhoneVerificationService``, to retrieve the localized message.
+
+All this is optional. That is, if you don't set ``I18N`` option, everything works as before.
 
 Usage
 -----

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,6 +53,19 @@ Configuration
 
 This would create ``SMSVerification`` table, which is used to store ``phone_number``, ``session_token`` and ``security_code``.
 
+i18n Support
+------------
+
+If you would like to internationalize the verification messages, set `I18N` to `True`. This would cause the
+`PhoneVerificationService` to attempt to translate the `MESSAGE` string using Django's internationalization
+primitive `django.utils.translation.gettext`.
+
+To expose this capability to the clients, `PhoneVerificationService` constructor supports an additional parameter,
+`language`, which is the desired language locale code which will be looked up for a localized version of `MESSAGE`.
+Also, `VerificationViewSet.register` endpoint supports an optional `language` POST data argument where you can
+specify the locale code for the desired verification message language. This locale code will be eventually passed
+to `PhoneVerificationService`, to try and retrieve the localized message.
+
 Usage
 -----
 

--- a/phone_verify/api.py
+++ b/phone_verify/api.py
@@ -21,7 +21,8 @@ class VerificationViewSet(viewsets.GenericViewSet):
         serializer = PhoneSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         session_token = send_security_code_and_generate_session_token(
-            str(serializer.validated_data["phone_number"])
+            str(serializer.validated_data["phone_number"]),
+            serializer.validated_data['language']
         )
         return response.Ok({"session_token": session_token})
 

--- a/phone_verify/serializers.py
+++ b/phone_verify/serializers.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 class PhoneSerializer(serializers.Serializer):
     phone_number = PhoneNumberField()
+    language = serializers.CharField(default='')
 
 
 class SMSVerificationSerializer(serializers.Serializer):

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps =
     django32: Django>=3.2,<3.2.5
     django40: Django>=4.0
 commands =
-    pytest --cov -v --tb=native
+    pytest --cov -v --tb=native {posargs}


### PR DESCRIPTION
A small tweak to the code to support localizing the verification message. This is a crucial requirement for many multilingual systems.