### PR TITLE
feat: add internationalization support for verification messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Release Notes
 
 Added
 """""
+- **Internationalization (i18n)**: Added support for localizing verification messages based on the ``Accept-Language`` HTTP header. The library now automatically detects the user's preferred language and sends verification messages in that language using Django's translation system. Contributed by `Hari Mahadevan <https://github.com/harikvpy>`_.
 - **Documentation**: Completely overhauled documentation to professional, enterprise-grade quality:
 
   - **Getting Started Guide** - Expanded with prerequisites, step-by-step configuration, environment variables, and testing instructions

--- a/phone_verify/api.py
+++ b/phone_verify/api.py
@@ -20,8 +20,18 @@ class VerificationViewSet(viewsets.GenericViewSet):
     def register(self, request):
         serializer = PhoneSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+
+        # Extract language from Accept-Language header
+        # Format: "en-US,en;q=0.9,es;q=0.8" -> take first language "en-US"
+        accept_language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
+        language = None
+        if accept_language:
+            # Take first language, strip quality params (e.g., "en-US;q=0.9" -> "en-US")
+            language = accept_language.split(',')[0].split(';')[0].strip() or None
+
         session_token = send_security_code_and_generate_session_token(
-            str(serializer.validated_data["phone_number"])
+            str(serializer.validated_data["phone_number"]),
+            language=language
         )
         return response.Ok({"session_token": session_token})
 


### PR DESCRIPTION
Superseeds #79 

Add support for localizing SMS verification messages based on the Accept-Language HTTP header. The library now automatically detects the user's preferred language and sends verification messages in that language using Django's translation system.

Changes:
- Extract language from Accept-Language header in API endpoint
- Add language parameter to PhoneVerificationService
- Implement message translation using Django's override and gettext
- Add comprehensive i18n documentation with setup guide
- Add tests for i18n functionality in API and service layers
