### PR TITLE
chore: Update dependencies

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,10 +1,10 @@
 # Core Stuff
 # -------------------------------------
-PyJWT==2.10.1
+PyJWT==2.12.0
 
 # Configuration
 # -------------------------------------
-python-dotenv==1.2.1
+python-dotenv==1.2.2
 
 # Phone number related Stuff
 # -------------------------------------

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -3,7 +3,7 @@
 
 # Core Stuff
 # -------------------------------------
-Django==6.0
+Django==6.0.4
 djangorestframework==3.16.1
 
 # Code quality


### PR DESCRIPTION
Combines the installable dependabot dependency bumps into a single change:

- PyJWT `2.10.1` -> `2.12.0` (#128)
- Django `6.0` -> `6.0.4` (#129)
- python-dotenv `1.2.1` -> `1.2.2` (#131)

Excludes the pytest bump (#130): `pytest==9.0.3` is not available on the package index (latest is `8.3.5`), so it fails to install in CI. pytest stays at `8.3.5`.

Once merged, the individual dependabot PRs can be closed.