### PR TITLE
feat: add verify_security_code service function and fix docs drift

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,8 +193,11 @@ Quick Start
 
 .. code-block:: python
 
-    from phone_verify.services import send_security_code_and_generate_session_token
-    from phone_verify.services import verify_security_code
+    from phone_verify.backends.base import BaseBackend
+    from phone_verify.services import (
+        send_security_code_and_generate_session_token,
+        verify_security_code,
+    )
 
     # Send verification code via SMS
     session_token = send_security_code_and_generate_session_token(
@@ -202,16 +205,17 @@ Quick Start
     )
     # User receives SMS: "Welcome to Phone Verify! Please use security code 847291 to proceed."
 
-    # Verify the code user entered
-    try:
-        verify_security_code(
-            phone_number="+1234567890",
-            security_code="847291",
-            session_token=session_token
-        )
+    # Verify the code user entered. Returns a (verification, status) tuple
+    # where status is one of the BaseBackend status constants.
+    verification, status = verify_security_code(
+        phone_number="+1234567890",
+        security_code="847291",
+        session_token=session_token,
+    )
+    if status == BaseBackend.SECURITY_CODE_VALID:
         print("✓ Phone number verified successfully!")
-    except Exception as e:
-        print(f"✗ Verification failed: {e}")
+    else:
+        print(f"✗ Verification failed with status {status}")
 
 Documentation
 -------------

--- a/docs/advanced_examples.rst
+++ b/docs/advanced_examples.rst
@@ -608,8 +608,11 @@ First, ensure Django's internationalization is enabled in your ``settings.py``:
 Create Translation Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create translation files for your verification message. The message template in ``PHONE_VERIFICATION['MESSAGE']``
-will be automatically translated:
+Create translation files for your verification message. At send time the message
+in ``PHONE_VERIFICATION['MESSAGE']`` is passed through ``gettext``, so it is only
+translated if you add that exact string as a ``msgid`` in your ``.po`` files. The
+setting is a plain string with no ``_()`` wrapper, so ``makemessages`` will not
+discover it for you; add the ``msgid`` manually (shown below):
 
 .. code-block:: bash
 

--- a/docs/advanced_examples.rst
+++ b/docs/advanced_examples.rst
@@ -608,11 +608,15 @@ First, ensure Django's internationalization is enabled in your ``settings.py``:
 Create Translation Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create translation files for your verification message. At send time the message
-in ``PHONE_VERIFICATION['MESSAGE']`` is passed through ``gettext``, so it is only
-translated if you add that exact string as a ``msgid`` in your ``.po`` files. The
-setting is a plain string with no ``_()`` wrapper, so ``makemessages`` will not
-discover it for you; add the ``msgid`` manually (shown below):
+Create translation files for your verification message. The message in
+``PHONE_VERIFICATION['MESSAGE']`` is passed through ``gettext`` only when a
+language is set, either from the ``Accept-Language`` header or by passing
+``language=`` explicitly. With no language set, the message is sent as-is.
+
+Even with a language set, the string is translated only if you add it as a
+``msgid`` in your ``.po`` files. The setting is a plain string with no ``_()``
+wrapper, so ``makemessages`` will not discover it for you; add the ``msgid``
+manually (shown below):
 
 .. code-block:: bash
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -60,6 +60,36 @@ PhoneVerificationService
       session_token = send_security_code_and_generate_session_token("+1234567890")
       # Returns: "eyJ0eXAiOiJKV1QiLCJhbGc..."
 
+.. py:function:: phone_verify.services.verify_security_code(phone_number, security_code, session_token)
+
+   Thin wrapper over the configured backend's ``validate_security_code()``. Looks up
+   the stored verification and validates the submitted code.
+
+   :param str phone_number: The phone number being verified
+   :param str security_code: The code the user submitted
+   :param str session_token: The session token returned during registration
+   :return: A ``(verification, status)`` tuple. ``verification`` is the
+            ``SMSVerification`` instance (or ``None`` if no record matched), and
+            ``status`` is one of the ``BaseBackend`` status constants (e.g.
+            ``BaseBackend.SECURITY_CODE_VALID``).
+   :rtype: tuple
+
+   **Example:**
+
+   .. code-block:: python
+
+      from phone_verify.backends.base import BaseBackend
+      from phone_verify.services import verify_security_code
+
+      verification, status = verify_security_code(
+          phone_number="+1234567890",
+          security_code="123456",
+          session_token=session_token,
+      )
+      if status == BaseBackend.SECURITY_CODE_VALID:
+          # Phone number verified
+          ...
+
 Backends
 --------
 
@@ -77,6 +107,7 @@ BaseBackend
    - ``SECURITY_CODE_EXPIRED = 2`` - Code has expired
    - ``SECURITY_CODE_VERIFIED = 3`` - Code already used (when ``VERIFY_SECURITY_CODE_ONLY_ONCE=True``)
    - ``SESSION_TOKEN_INVALID = 4`` - Session token doesn't match
+   - ``SECURITY_CODE_TOO_MANY_ATTEMPTS = 5`` - Too many failed attempts (when ``MAX_FAILED_ATTEMPTS`` is exceeded)
 
    **Abstract Methods (must be implemented):**
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -68,10 +68,12 @@ PhoneVerificationService
    :param str phone_number: The phone number being verified
    :param str security_code: The code the user submitted
    :param str session_token: The session token returned during registration
-   :return: A ``(verification, status)`` tuple. ``verification`` is the
-            ``SMSVerification`` instance (or ``None`` if no record matched), and
-            ``status`` is one of the ``BaseBackend`` status constants (e.g.
-            ``BaseBackend.SECURITY_CODE_VALID``).
+   :return: A ``(verification, status)`` tuple. ``status`` is one of the
+            ``BaseBackend`` status constants (e.g. ``BaseBackend.SECURITY_CODE_VALID``).
+            ``verification`` is the matching ``SMSVerification`` instance, ``None``
+            when no record matched the session token, or an empty ``QuerySet`` when a
+            sandbox backend bypassed the code check. Branch on ``status``, not on
+            ``verification``.
    :rtype: tuple
 
    **Example:**
@@ -79,7 +81,14 @@ PhoneVerificationService
    .. code-block:: python
 
       from phone_verify.backends.base import BaseBackend
-      from phone_verify.services import verify_security_code
+      from phone_verify.services import (
+          send_security_code_and_generate_session_token,
+          verify_security_code,
+      )
+
+      session_token = send_security_code_and_generate_session_token("+1234567890")
+
+      # ... user receives the SMS and submits the code back to you ...
 
       verification, status = verify_security_code(
           phone_number="+1234567890",

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -172,8 +172,9 @@ Main service class that orchestrates verification:
 .. code-block:: python
 
     class PhoneVerificationService:
-        def send_verification(self, number, security_code, context=None)
-            # Formats the message and sends the SMS via the backend
+        def send_verification(self, number, security_code, context=None):
+            """Formats the message and sends the SMS via the backend."""
+            ...
 
 Sending a code and generating a session token is done through the
 ``send_security_code_and_generate_session_token()`` service function, and
@@ -190,11 +191,13 @@ Abstract interface for SMS providers:
 .. code-block:: python
 
     class BaseBackend:
-        def send_sms(number, message)              # Send single SMS
-        def send_bulk_sms(numbers, message)        # Send bulk SMS
-        def generate_security_code()               # Generate random code
-        def generate_session_token(phone_number)   # Generate JWT token
-        def validate_security_code(...)            # Validate code
+        def send_sms(number, message): ...              # Send single SMS
+        def send_bulk_sms(numbers, message): ...        # Send bulk SMS
+        def generate_security_code(): ...               # Generate random code
+        def generate_session_token(phone_number): ...   # Generate JWT token
+        def validate_security_code(                     # Validate code
+            security_code, phone_number, session_token
+        ): ...
 
 Concrete implementations:
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -172,11 +172,15 @@ Main service class that orchestrates verification:
 .. code-block:: python
 
     class PhoneVerificationService:
-        def send_verification(self, context=None)
-            # Generates code, sends SMS, returns session token
+        def send_verification(self, number, security_code, context=None)
+            # Formats the message and sends the SMS via the backend
 
-        def verify(self, security_code, session_token)
-            # Validates code and token, returns success/failure
+Sending a code and generating a session token is done through the
+``send_security_code_and_generate_session_token()`` service function, and
+verification is done through the ``verify_security_code()`` service function
+(or the ``SMSVerificationSerializer``), both of which delegate to the
+backend's ``validate_security_code()``. The service class itself has no
+``verify`` method.
 
 3. Backend Classes
 ^^^^^^^^^^^^^^^^^^
@@ -234,25 +238,23 @@ This prevents code reuse attacks.
 Database Schema
 ---------------
 
-The ``phone_verify_smsverification`` table structure:
+The ``sms_verification`` table structure:
 
 .. code-block:: sql
 
-    CREATE TABLE phone_verify_smsverification (
-        id               SERIAL PRIMARY KEY,
-        phone_number     VARCHAR(15) NOT NULL,  -- E.164 format
-        session_token    TEXT NOT NULL,         -- JWT token
-        security_code    VARCHAR(120) NOT NULL, -- Hashed or plain code
+    CREATE TABLE sms_verification (
+        id               UUID PRIMARY KEY,        -- uuid4, not auto-increment
+        security_code    VARCHAR(120) NOT NULL,   -- plain code sent via SMS
+        phone_number     VARCHAR(128) NOT NULL,   -- E.164 format
+        session_token    VARCHAR(500) NOT NULL,   -- JWT token
         is_verified      BOOLEAN DEFAULT FALSE,
-        created_at       TIMESTAMP DEFAULT NOW(),
+        failed_attempts  INTEGER DEFAULT 0,       -- brute-force counter
+        created_at       TIMESTAMP NOT NULL,
+        modified_at      TIMESTAMP NOT NULL,
 
-        CONSTRAINT unique_phone_session
-            UNIQUE (phone_number, session_token)
+        CONSTRAINT unique_code_phone_session
+            UNIQUE (security_code, phone_number, session_token)
     );
-
-    -- Index for fast lookups during verification
-    CREATE INDEX idx_phone_token
-        ON phone_verify_smsverification(phone_number, session_token);
 
 Configuration Flow
 ------------------

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -177,10 +177,11 @@ Main service class that orchestrates verification:
             ...
 
 Sending a code and generating a session token is done through the
-``send_security_code_and_generate_session_token()`` service function, and
-verification is done through the ``verify_security_code()`` service function
-(or the ``SMSVerificationSerializer``), both of which delegate to the
-backend's ``validate_security_code()``. The service class itself has no
+``send_security_code_and_generate_session_token()`` service function, which
+delegates to the backend's ``create_security_code_and_session_token()`` and
+``send_sms()``. Verification is done through the ``verify_security_code()``
+service function, or the ``SMSVerificationSerializer``; both of those delegate
+to the backend's ``validate_security_code()``. The service class itself has no
 ``verify`` method.
 
 3. Backend Classes

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -194,20 +194,28 @@ You can quickly test if everything is working using the Django shell:
 
     python manage.py shell
 
-    >>> from phone_verify.services import send_security_code_and_generate_session_token
-    >>> from phone_verify.services import verify_security_code
+    >>> from phone_verify.backends.base import BaseBackend
+    >>> from phone_verify.services import (
+    ...     send_security_code_and_generate_session_token,
+    ...     verify_security_code,
+    ... )
     >>>
     >>> # Send verification code
     >>> phone = "+1234567890"  # Use your real phone number for testing
     >>> session_token = send_security_code_and_generate_session_token(phone)
     >>> print(f"Session token: {session_token}")
     >>>
-    >>> # Check your phone for the SMS, then verify
+    >>> # Check your phone for the SMS, then verify. verify_security_code
+    >>> # returns a (verification, status) tuple.
     >>> code = "123456"  # Enter the code you received
-    >>> verify_security_code(phone, code, session_token)
-    (<QuerySet []>, 'SECURITY_CODE_VALID')
+    >>> verification, status = verify_security_code(phone, code, session_token)
+    >>> status == BaseBackend.SECURITY_CODE_VALID
+    True
+    >>> status  # SECURITY_CODE_VALID is the integer 0
+    0
 
-If you see ``'SECURITY_CODE_VALID'``, congratulations! Your setup is working correctly.
+If ``status`` equals ``BaseBackend.SECURITY_CODE_VALID`` (the integer ``0``),
+congratulations! Your setup is working correctly.
 
 .. tip::
     **Testing Without Real SMS**: To test without sending actual SMS messages, use a sandbox backend.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,19 +25,22 @@ Quick Example
 
 .. code-block:: python
 
-    from phone_verify.services import send_security_code_and_generate_session_token
-    from phone_verify.services import verify_security_code
+    from phone_verify.backends.base import BaseBackend
+    from phone_verify.services import (
+        send_security_code_and_generate_session_token,
+        verify_security_code,
+    )
 
     # Send verification code via SMS
     session_token = send_security_code_and_generate_session_token("+1234567890")
 
     # User receives SMS: "Your verification code is 847291"
 
-    # Verify the code
-    verify_security_code("+1234567890", "847291", session_token)
-    # Returns: SECURITY_CODE_VALID
+    # Verify the code. Returns a (verification, status) tuple.
+    verification, status = verify_security_code("+1234567890", "847291", session_token)
+    assert status == BaseBackend.SECURITY_CODE_VALID
 
-That's it! Phone verification in 3 lines of code.
+That's it! Phone verification in a few lines of code.
 
 Installation
 ------------

--- a/phone_verify/services.py
+++ b/phone_verify/services.py
@@ -122,3 +122,18 @@ def send_security_code_and_generate_session_token(phone_number, language=None):
             "{error}".format(phone_number=phone_number, error=exc)
         )
     return session_token
+
+
+def verify_security_code(phone_number, security_code, session_token):
+    """Verify a security code for a phone number + session token.
+
+    Thin wrapper over the configured backend's validation. Returns a tuple of
+    ``(verification, status)`` where ``status`` is one of the ``BaseBackend``
+    status constants (e.g. ``BaseBackend.SECURITY_CODE_VALID``).
+    """
+    backend = get_sms_backend(phone_number)
+    return backend.validate_security_code(
+        security_code=security_code,
+        phone_number=phone_number,
+        session_token=session_token,
+    )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,10 +13,13 @@ from twilio.base.exceptions import TwilioRestException
 
 # phone_verify Stuff
 import phone_verify.services
+from phone_verify.backends import get_sms_backend
+from phone_verify.backends.base import BaseBackend
 from phone_verify.constants import get_security_code_expiration
 from phone_verify.services import (
     PhoneVerificationService,
     send_security_code_and_generate_session_token,
+    verify_security_code,
 )
 
 from .test_backends import _get_backend_cls
@@ -184,6 +187,41 @@ def test_generate_message_from_custom_backend(settings):
     msg = svc._generate_message("999999", context={"extra": "runtime"})
 
     assert msg == "Custom: 999999 / runtime"
+
+
+def test_verify_security_code_valid(client, backend):
+    with override_settings(PHONE_VERIFICATION=backend):
+        phone_number = "+13478379634"
+        sms_backend = get_sms_backend(phone_number)
+        security_code, session_token = (
+            sms_backend.create_security_code_and_session_token(phone_number)
+        )
+
+        verification, status = verify_security_code(
+            phone_number=phone_number,
+            security_code=security_code,
+            session_token=session_token,
+        )
+
+        assert status == BaseBackend.SECURITY_CODE_VALID
+        assert verification is not None
+
+
+def test_verify_security_code_invalid(client, backend):
+    with override_settings(PHONE_VERIFICATION=backend):
+        phone_number = "+13478379634"
+        sms_backend = get_sms_backend(phone_number)
+        _, session_token = sms_backend.create_security_code_and_session_token(
+            phone_number
+        )
+
+        _, status = verify_security_code(
+            phone_number=phone_number,
+            security_code="000000",
+            session_token=session_token,
+        )
+
+        assert status == BaseBackend.SECURITY_CODE_INVALID
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

The docs taught `phone_verify.services.verify_security_code(...)`, but no such function existed. Verification only happened inside `SMSVerificationSerializer.validate()`. This adds the missing public function and corrects every doc that referenced it or otherwise drifted from the code.

- Add `verify_security_code(phone_number, security_code, session_token)` to `services.py`, a thin wrapper over the configured backend's `validate_security_code(...)`. It returns the real `(verification, status)` tuple, where `status` is a `BaseBackend` constant.
- Fix `README.rst` and `docs/index.rst` quick-start examples to unpack `(verification, status)` and compare against `BaseBackend.SECURITY_CODE_VALID` (previously treated the call as raising or returning a string).
- Fix `docs/getting_started.rst` shell session, which showed a fabricated return value.
- Fix `docs/architecture.rst`: correct `send_verification` signature, remove the nonexistent `verify()` method, and rewrite the SQL schema to match the real model (table `sms_verification`, UUID PK, triple unique constraint, `failed_attempts` and `modified_at` fields, plain-text code).
- `docs/api_reference.rst`: add the missing `SECURITY_CODE_TOO_MANY_ATTEMPTS` status constant and document `verify_security_code`.
- `docs/advanced_examples.rst`: correct the i18n wording, which oversold automatic translation of the `MESSAGE` string.

## Test plan

- Added `test_verify_security_code_valid` and `test_verify_security_code_invalid`, parametrized across all four backends.
- Full suite: 143 passed. Ruff clean.