### PR TITLE
fix: default backend exception_class and drop unreachable serializer branch

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -341,10 +341,11 @@ SMSVerificationSerializer
 
    Automatically validates the security code against the backend and raises appropriate errors:
 
-   - "Security code is not valid"
-   - "Session Token mis-match"
+   - "Security code is not valid" (also returned when the ``phone_number`` and
+     ``session_token`` pair matches no record, so no single field is named)
    - "Security code has expired"
    - "Security code is already verified"
+   - "Too many failed verification attempts. Please request a new code."
 
    **Usage:**
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -153,10 +153,16 @@ Verification Issues
 - Increase expiration time if appropriate
 - Log verification attempts to debug
 
-"Session Token mis-match"
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Session token does not match
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Problem:** The session token provided doesn't match the one in the database.
+
+The API reports this as ``"Security code is not valid"``. The same error covers a
+wrong ``phone_number``, a wrong ``session_token``, and a wrong ``security_code``,
+so that a caller cannot tell which of the three was rejected. When calling
+``verify_security_code()`` directly, the returned status distinguishes them:
+this case is ``BaseBackend.SESSION_TOKEN_INVALID``.
 
 **Causes:**
 

--- a/phone_verify/backends/base.py
+++ b/phone_verify/backends/base.py
@@ -24,8 +24,16 @@ class BaseBackend(metaclass=ABCMeta):
     SESSION_TOKEN_INVALID = 4
     SECURITY_CODE_TOO_MANY_ATTEMPTS = 5
 
-    def __init__(self, **settings):
-        self.exception_class = None
+    # Exception a provider raises from `send_sms`, caught and logged when
+    # sending a verification. Concrete backends narrow this to their provider's
+    # error type. Defaults to `Exception` so backends that never set it still
+    # get their errors logged rather than raising from the `except` clause.
+    exception_class = Exception
+
+    # Accepts and discards `**settings` so concrete backends can call
+    # `super().__init__(**options)`. Not abstract: there is nothing to override.
+    def __init__(self, **settings):  # noqa: B027
+        pass
 
     @abstractmethod
     def send_sms(self, number, message):

--- a/phone_verify/serializers.py
+++ b/phone_verify/serializers.py
@@ -40,11 +40,14 @@ class SMSVerificationSerializer(serializers.Serializer):
             session_token=session_token,
         )
 
-        if verification is None:
-            raise serializers.ValidationError(_("Security code is not valid"))
-        elif token_validatation == backend.SESSION_TOKEN_INVALID:
-            raise serializers.ValidationError(_("Session Token mis-match"))
-        elif token_validatation == backend.SECURITY_CODE_INVALID:
+        # A missing record, SESSION_TOKEN_INVALID and SECURITY_CODE_INVALID all
+        # report the same way: the (phone_number, session_token) pair matched
+        # nothing, or the code was wrong. Any of the three fields could be at
+        # fault, so do not name one.
+        if verification is None or token_validatation in (
+            backend.SESSION_TOKEN_INVALID,
+            backend.SECURITY_CODE_INVALID,
+        ):
             raise serializers.ValidationError(_("Security code is not valid"))
         elif token_validatation == backend.SECURITY_CODE_EXPIRED:
             raise serializers.ValidationError(_("Security code has expired"))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -140,6 +140,36 @@ def test_deprecation_warning_for_old_expiration_setting(backend):
             assert "SECURITY_CODE_EXPIRATION_TIME is deprecated" in str(w[0].message)
 
 
+class BackendWithoutExceptionClass(BaseBackend):
+    """A custom backend shaped like the ones in docs/customization.rst.
+
+    It never sets `exception_class`, so it relies on the BaseBackend default.
+    """
+
+    def send_sms(self, number, message):
+        raise RuntimeError("provider is down")
+
+
+def test_provider_error_is_logged_when_backend_omits_exception_class(mocker):
+    """A backend that never sets `exception_class` must still log, not raise TypeError."""
+    settings_dict = {
+        "BACKEND": "tests.test_services.BackendWithoutExceptionClass",
+        "OPTIONS": {},
+        "TOKEN_LENGTH": 6,
+        "MESSAGE": "Your code is {security_code}",
+        "APP_NAME": "Phone Verify",
+        "SECURITY_CODE_EXPIRATION_SECONDS": 600,
+        "VERIFY_SECURITY_CODE_ONLY_ONCE": True,
+    }
+    with override_settings(PHONE_VERIFICATION=settings_dict):
+        mock_logger = mocker.patch("phone_verify.services.logger")
+        session_token = send_security_code_and_generate_session_token("+13478379634")
+
+    assert session_token
+    mock_logger.error.assert_called_once()
+    assert "provider is down" in mock_logger.error.call_args[0][0]
+
+
 class DummyBackend:
     def __init__(self):
         self.sent_messages = []


### PR DESCRIPTION
## Summary

Two defects in the verification error paths, both found by cross-checking the documentation against running code.

**`exception_class` defaulted to `None`.** `BaseBackend.__init__` set `self.exception_class = None`, and `send_security_code_and_generate_session_token` catches `service.backend.exception_class`. A backend that never set the attribute therefore raised `TypeError: catching classes that do not inherit from BaseException is not allowed` on any send failure, masking the real provider error. None of the custom backend examples in `docs/customization.rst`, `docs/troubleshooting.rst`, or `docs/configuration.rst` set it, so backends written from the documentation hit this. It is now a class attribute defaulting to `Exception`, so it applies even to backends that do not call `super().__init__()`. The built-in Twilio and Nexmo backends continue to narrow it to their provider's error type.

**The `SESSION_TOKEN_INVALID` serializer branch was unreachable.** `validate_security_code` returns that status only together with a `None` verification, and the serializer tested `verification is None` first, so `"Session Token mis-match"` could never be returned. The two equivalent conditions are merged into the existing `"Security code is not valid"` error. Reporting them identically also avoids revealing which of `phone_number`, `session_token`, or `security_code` was rejected. Callers that need to distinguish the cases still get the specific status from `verify_security_code()`.

Docs that promised the unreachable error are corrected, and the serializer error list now includes the brute-force message, which was previously undocumented.

## Test plan

- New `test_provider_error_is_logged_when_backend_omits_exception_class` builds a backend shaped like the documented examples and asserts the provider error is logged rather than raised. Verified it fails with the old `None` default.
- `phone_verify/serializers.py` goes from 97% to 100% coverage, confirming the removed branch was the only uncovered line.
- Full suite: 145 passed. Ruff clean.